### PR TITLE
Add normal mode operator (Luadev-RunOperator) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Use the folllowing mappings to execute lua code:
 Binding                       | Action
 -------------------------     | ------
 `<Plug>(Luadev-RunLine)`      | Execute the current line
-`<Plug>(Luadev-Run)`          | in visual mode: execute visual selection
-`<Plug>(Luadev-RunOperator)`  | in normal mode: execute the motion selection, if linewise the whole lines
+`<Plug>(Luadev-Run)`          | Operator to execute lua code over a movement or text object.
 `<Plug>(Luadev-RunWord)`      | Eval identifier under cursor, including `table.attr`
 `<Plug>(Luadev-Complete)`     | in insert mode: complete (nested) global table fields
 
@@ -27,7 +26,7 @@ Planned features:
  - [x] autodetect expression vs statements
  - [x] Fix `inspect.lua` to use `tostring()` on userdata (done on a local copy)
  - [x] completion of global names and table attributes (WIP: basic implementation done)
- - [x] make `<Plug>(Luadev-RunOperator)` a proper operator
+ - [x] make `<Plug>(Luadev-Run)` a proper operator
  - [ ] solution for step-wise execution of code with `local` assignments (such
         as a flag to copy local values to an env)
  - [x] tracebacks

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ The `:Luadev` command will open an scratch window which will show output from ex
 
 Use the folllowing mappings to execute lua code:
 
-Binding                   | Action
-------------------------- | ------
-`<Plug>(Luadev-RunLine)`  | Execute the current line
-`<Plug>(Luadev-Run)`      | in visual mode: execute visual selection
-`<Plug>(Luadev-RunWord)`  | Eval identifier under cursor, including `table.attr`
-`<Plug>(Luadev-Complete)` | in insert mode: complete (nested) global table fields
+Binding                       | Action
+-------------------------     | ------
+`<Plug>(Luadev-RunLine)`      | Execute the current line
+`<Plug>(Luadev-Run)`          | in visual mode: execute visual selection
+`<Plug>(Luadev-RunOperator)`  | in normal mode: execute the motion selection, if linewise the whole lines
+`<Plug>(Luadev-RunWord)`      | Eval identifier under cursor, including `table.attr`
+`<Plug>(Luadev-Complete)`     | in insert mode: complete (nested) global table fields
 
 If the code is a expression, it will be evaluated, and the result shown with
 `inspect.lua`. Otherwise it will be executed as a block of code. A top-level
@@ -26,7 +27,7 @@ Planned features:
  - [x] autodetect expression vs statements
  - [x] Fix `inspect.lua` to use `tostring()` on userdata (done on a local copy)
  - [x] completion of global names and table attributes (WIP: basic implementation done)
- - [ ] make `<Plug>(Luadev-Run)` a proper operator
+ - [x] make `<Plug>(Luadev-RunOperator)` a proper operator
  - [ ] solution for step-wise execution of code with `local` assignments (such
         as a flag to copy local values to an env)
  - [x] tracebacks

--- a/plugin/luadev.vim
+++ b/plugin/luadev.vim
@@ -1,23 +1,47 @@
 command! Luadev lua require'luadev'.start()
 
 noremap <Plug>(Luadev-RunLine) <Cmd>lua require'luadev'.exec(vim.api.nvim_get_current_line())<cr>
-vnoremap <silent> <Plug>(Luadev-Run) :<c-u>call luaeval("require'luadev'.exec(_A)", <SID>get_visual_selection())<cr>
+vnoremap <silent> <Plug>(Luadev-Run) :<c-u>call <SID>luadev_run_operator('visual')<cr>
+noremap <silent> <Plug>(Luadev-RunOperator) :<c-u>set opfunc=<SID>luadev_run_operator<cr>g@
 noremap <silent> <Plug>(Luadev-RunWord) :<c-u>call luaeval("require'luadev'.exec(_A)", <SID>get_current_word())<cr>
 inoremap <Plug>(Luadev-Complete) <Cmd>lua require'luadev.complete'()<cr>
 
+
 " thanks to @xolox on stackoverflow
-function! s:get_visual_selection()
-    let [lnum1, col1] = getpos("'<")[1:2]
-    let [lnum2, col2] = getpos("'>")[1:2]
+" same function for visual and normal. Except visual passes a parameter.
+function! s:luadev_run_operator(type = '')
+    if a:type == "visual"
+        let mode = "visual"
+    else
+        let mode = "normal"
+    end
+
+    if mode == 'visual'
+        let [lnum1, col1] = getpos("'<")[1:2]
+        let [lnum2, col2] = getpos("'>")[1:2]
+    elseif mode == 'normal'
+        let [lnum1, col1] = getpos("'[")[1:2]
+        let [lnum2, col2] = getpos("']")[1:2]
+    endif
 
     if lnum1 > lnum2
       let [lnum1, col1, lnum2, col2] = [lnum2, col2, lnum1, col1]
     endif
 
+    " Normal motions that are more than one line are forced to linewise
+    if lnum1 != lnum2 && mode =="normal"
+        let linewise = v:true
+    else
+        let linewise = v:false
+    end
+
     let lines = getline(lnum1, lnum2)
-    let lines[-1] = lines[-1][: col2 - (&selection == 'inclusive' ? 1 : 2)]
-    let lines[0] = lines[0][col1 - 1:]
-    return join(lines, "\n")."\n"
+    if linewise == v:false
+        let lines[-1] = lines[-1][: col2 - (&selection == 'inclusive' ? 1 : 2)]
+        let lines[0] = lines[0][col1 - 1:]
+    end
+    let lines =  join(lines, "\n")."\n"
+    call luaeval("require'luadev'.exec(_A)", lines)
 endfunction
 
 function! s:get_current_word()

--- a/plugin/luadev.vim
+++ b/plugin/luadev.vim
@@ -21,7 +21,7 @@ function! s:luadev_run_operator(is_op)
         let lines[0] = lines[0][col1 - 1:]
     end
     let lines =  join(lines, "\n")."\n"
-    call luaeval("require'luadev'.exec(_A)", lines)
+    call v:lua.require'luadev'.exec(lines)
 endfunction
 
 function! s:get_current_word()

--- a/plugin/luadev.vim
+++ b/plugin/luadev.vim
@@ -2,7 +2,7 @@ command! Luadev lua require'luadev'.start()
 
 noremap <Plug>(Luadev-RunLine) <Cmd>lua require'luadev'.exec(vim.api.nvim_get_current_line())<cr>
 vnoremap <silent> <Plug>(Luadev-Run) :<c-u>call <SID>luadev_run_operator(v:true)<cr>
-noremap <silent> <Plug>(Luadev-RunOperator) :<c-u>set opfunc=<SID>luadev_run_operator<cr>g@
+nnoremap <silent> <Plug>(Luadev-Run) :<c-u>set opfunc=<SID>luadev_run_operator<cr>g@
 noremap <silent> <Plug>(Luadev-RunWord) :<c-u>call luaeval("require'luadev'.exec(_A)", <SID>get_current_word())<cr>
 inoremap <Plug>(Luadev-Complete) <Cmd>lua require'luadev.complete'()<cr>
 

--- a/plugin/luadev.vim
+++ b/plugin/luadev.vim
@@ -1,42 +1,22 @@
 command! Luadev lua require'luadev'.start()
 
 noremap <Plug>(Luadev-RunLine) <Cmd>lua require'luadev'.exec(vim.api.nvim_get_current_line())<cr>
-vnoremap <silent> <Plug>(Luadev-Run) :<c-u>call <SID>luadev_run_operator('visual')<cr>
+vnoremap <silent> <Plug>(Luadev-Run) :<c-u>call <SID>luadev_run_operator(v:true)<cr>
 noremap <silent> <Plug>(Luadev-RunOperator) :<c-u>set opfunc=<SID>luadev_run_operator<cr>g@
 noremap <silent> <Plug>(Luadev-RunWord) :<c-u>call luaeval("require'luadev'.exec(_A)", <SID>get_current_word())<cr>
 inoremap <Plug>(Luadev-Complete) <Cmd>lua require'luadev.complete'()<cr>
 
-
 " thanks to @xolox on stackoverflow
-" same function for visual and normal. Except visual passes a parameter.
-function! s:luadev_run_operator(type = '')
-    if a:type == "visual"
-        let mode = "visual"
-    else
-        let mode = "normal"
-    end
-
-    if mode == 'visual'
-        let [lnum1, col1] = getpos("'<")[1:2]
-        let [lnum2, col2] = getpos("'>")[1:2]
-    elseif mode == 'normal'
-        let [lnum1, col1] = getpos("'[")[1:2]
-        let [lnum2, col2] = getpos("']")[1:2]
-    endif
+function! s:luadev_run_operator(is_op)
+    let [lnum1, col1] = getpos(a:is_op ? "'<" : "'[")[1:2]
+    let [lnum2, col2] = getpos(a:is_op ? "'>" : "']")[1:2]
 
     if lnum1 > lnum2
       let [lnum1, col1, lnum2, col2] = [lnum2, col2, lnum1, col1]
     endif
 
-    " Normal motions that are more than one line are forced to linewise
-    if lnum1 != lnum2 && mode =="normal"
-        let linewise = v:true
-    else
-        let linewise = v:false
-    end
-
     let lines = getline(lnum1, lnum2)
-    if linewise == v:false
+    if  a:is_op == v:true || lnum1 == lnum2
         let lines[-1] = lines[-1][: col2 - (&selection == 'inclusive' ? 1 : 2)]
         let lines[0] = lines[0][col1 - 1:]
     end


### PR DESCRIPTION
Hello Björn Linse Copilot Helmsman 😄  In this PR I attempt to add a normal mode operator `(Luadev-RunOperator)`.

The logic is abstracted into the `s:luadev_run_operator` function that receives the first parameter `"visual"` to know it should use the visual range. Otherwise work with motions. In this case motions that expand over one line execute code linewise from the start to the end. This makes motions `j,k,%,/,?` be more ergonomic I believe.