### PR TITLE
Allow for bar in Luadev command

### DIFF
--- a/plugin/luadev.vim
+++ b/plugin/luadev.vim
@@ -1,4 +1,4 @@
-command! Luadev lua require'luadev'.start()
+command! -bar Luadev lua require'luadev'.start()
 
 noremap <Plug>(Luadev-RunLine) <Cmd>lua require'luadev'.exec(vim.api.nvim_get_current_line())<cr>
 vnoremap <silent> <Plug>(Luadev-Run) :<c-u>call <SID>luadev_run_operator(v:true)<cr>


### PR DESCRIPTION
Allow me to do something like the following, to manipulate the luadev buffer:

```lua
vim.cmd [[ command LS Luadev | execute "normal! \<C-W>T" ]]
```